### PR TITLE
Streaming working and added time to shows with EPG info

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -6,6 +6,7 @@
 # http://iphone.cdn.viasat.tv/iphone/009/00916/S91659_djurakuten_jhtrvgxbmmxsz44a_iphone.m3u8'
 ####################################################################################################
 import re
+import datetime
 VIDEO_PREFIX = "/video/viaplay"
 
 ART = 'art-default.jpg'
@@ -410,7 +411,24 @@ def MakeMovieObject(item=[]):
         thumb = art
     if 'boxart' in content['images']:
         thumb = content['images']['boxart']['url']
-    return MovieObject(title    = content['title'],
+
+    title = content['title']
+    if "epg" in item:
+        start_time = datetime.datetime.strptime(item["epg"]["start"], "%Y-%m-%dT%H:%M:%S.000Z")
+        end_time = datetime.datetime.strptime(item["epg"]["streamEnd"], "%Y-%m-%dT%H:%M:%S.000Z")
+        now = datetime.datetime.now()
+
+        if start_time < now and now < end_time:
+            time = "Live"
+        else:
+            if start_time.strftime("%Y%m%d") == now.strftime("%Y%m%d"):
+                time = start_time.strftime("today at %H:%M")
+            else:
+                time = start_time.strftime("%b %d at %H:%M")
+
+        title = "%s (%s)" % (title, time)
+
+    return MovieObject(title    = title,
                        summary  = content['synopsis'],
                        thumb    = thumb,
                        art      = art,

--- a/Contents/Services/URL/viaplay/ServiceCode.pys
+++ b/Contents/Services/URL/viaplay/ServiceCode.pys
@@ -1,4 +1,6 @@
 import re, shutil
+from lxml.etree import HTMLParser, parse, tostring
+import StringIO
 
 IPAD_UA = 'Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X; en-us) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B176 Safari/7534.48.3'
 
@@ -91,6 +93,16 @@ def PlayVideo(url, platform):
         new_playlist      = RegeneratePlaylist(original_playlist.splitlines(), url[:url.rindex("/")])
         Log("JTDEBUG new_playlist:%s" % new_playlist)
         return new_playlist
+
+def GetStream(product):
+    site = Prefs['site'].lower()
+    stream_url = "http://play.viaplay." + site + "/api/playlist/v1?deviceKey="+ GetDeviceKey(site) + "&productId=%s" % product
+    # Some viaplay xml is broken, so parse it with a more lenient HTML parser instead
+    data = HTTP.Request(stream_url).content
+    parser = HTMLParser()
+    tree = parse(StringIO.StringIO(data), parser)
+    url = tree.xpath("/html/body/playlist/entries/entry/url")[0].text
+    return url
 
 ######################################
 # Plex is unable to handle relative playlist files and doesn't select the correct bandwidth


### PR DESCRIPTION
Streaming works, but the only problem is that some content requires additional authentication on the CDN the content is hosted (mostly saw problems when content is hosted at level3.net). Haven't figured out how to authenticate there.
